### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,11 @@
 # Ignore dotfiles
 .*.*
 
-*.[0-9]*
+# Ignore keys
+*.crt
+*.csr
+*.key
+*.pem
 
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Ignore everything
+*
+
+# Unignore all with extensions
+!*.*
+
+# Unignore all dirs
+!*/
+
+# Unignore Makefile
+!Makefile
+
+# Ignore dotfiles
+.*.*
+
+*.[0-9]*
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Compilation
 To compile the program, use something like:
 
 ```console
-    gcc ssl_server_nonblock.c -Wall -O0 -g3 -std=c99 -lcrypto -lssl -o ssl_server_nonblock 
+    gcc ssl_server_nonblock.c -Wall -O0 -g3 -std=c99 -lcrypto -lssl -o ssl_server_nonblock
 ```
 
 Or on MacOS:
@@ -44,8 +44,8 @@ these steps:
 
 1. Generate the private key, this is what we normally keep secret:
 ```console
-    openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
-    openssl rsa -passin pass:x -in server.pass.key -out server.key
+    openssl genrsa -des3 -passout pass:ABCD -out server.pass.key 2048
+    openssl rsa -passin pass:ABCD -in server.pass.key -out server.key
     rm -f server.pass.key
 ```
 2. Next generate the CSR.  We can leave the password empty when prompted

--- a/common.h
+++ b/common.h
@@ -17,6 +17,7 @@ it under the terms of the MIT license. See LICENSE for details.
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
 
 /* Global SSL context */
 SSL_CTX *ctx;


### PR DESCRIPTION
Did a couple of things:

1. Added gitignore: prerequisite files (*.d), executables, crypto keys, etc, are ignored
2. common.h was missing string.h (to compile on Linux)
3. Updated readme: the -pass: x does not work anymore (minimum 4 chars)

(Had different PR's but this seems quite straightforward)